### PR TITLE
FEATURE: String concatenation

### DIFF
--- a/test/Unit/TypeSystem/Resolver/BinaryOperation/BinaryOperationTypeResolverTest.php
+++ b/test/Unit/TypeSystem/Resolver/BinaryOperation/BinaryOperationTypeResolverTest.php
@@ -63,8 +63,19 @@ final class BinaryOperationTypeResolverTest extends TestCase
         ];
     }
 
+    public function stringConcatenationExamples(): array
+    {
+        return [
+            '"foo" + "bar"' => ['"foo" + "mhs"', StringType::get()],
+            'someString + "bar"' => ['someString + "bar"', StringType::get()],
+            '8 + 15 + 42 + someString' => ['8 + 15 + 42 + someString', StringType::get()],
+            'someNumber + someString' => ['someNumber + someString', StringType::get()]
+        ];
+    }
+
     /**
      * @dataProvider binaryOperationExamples
+     * @dataProvider stringConcatenationExamples
      * @test
      * @param string $binaryOperationAsString
      * @param TypeInterface $expectedType
@@ -72,7 +83,10 @@ final class BinaryOperationTypeResolverTest extends TestCase
      */
     public function resolvesBinaryOperationToResultingType(string $binaryOperationAsString, TypeInterface $expectedType): void
     {
-        $scope = new DummyScope();
+        $scope = new DummyScope(identifierToTypeMap: [
+            "someString" => StringType::get(),
+            "someNumber" => NumberType::get()
+        ]);
         $binaryOperationTypeResolver = new BinaryOperationTypeResolver(
             scope: $scope
         );


### PR DESCRIPTION
Was a fun thing to do :D Thanks to your great type system

Happy Easter!

```
"abc" + "def"
```

is currently transpiled to

```
'abc' + 'def'
```
which is not valid php (should be `.`)

Also if we trigger a typecheck (e.g.) when using it directly as return like:

```
export component Foo {  
    return "abc" + "def"
}
```

an expression will be thrown:

```
Uncaught Exception: @TODO: Operand must be of type number in src/TypeSystem/Resolver/BinaryOperation/BinaryOperationTypeResolver.php:89
```

now it transpiles correctly:

```
final class Foo extends BaseClass
{
    public function render(): string
    {
        return ('abc' . 'def');
    }
}
```

~i thought of the spec: if any of the operands is a string and the operator + is then well use string concatenation and resolve a string as return type~