### PR TITLE
BUGFIX: Ternary with nested variable access in condition

### DIFF
--- a/src/Parser/Ast/ExpressionNode.php
+++ b/src/Parser/Ast/ExpressionNode.php
@@ -111,6 +111,9 @@ final class ExpressionNode implements \JsonSerializable
                 break;
             default:
                 $root = IdentifierNode::fromTokens($tokens);
+                if (!Scanner::isEnd($tokens) && Scanner::type($tokens) === TokenType::PERIOD) {
+                    $root = AccessNode::fromTokens(new self(root: $root), $tokens);
+                }
                 break;
         }
 

--- a/src/Parser/Ast/ExpressionNode.php
+++ b/src/Parser/Ast/ExpressionNode.php
@@ -111,9 +111,6 @@ final class ExpressionNode implements \JsonSerializable
                 break;
             default:
                 $root = IdentifierNode::fromTokens($tokens);
-                if (!Scanner::isEnd($tokens) && Scanner::type($tokens) === TokenType::PERIOD) {
-                    $root = AccessNode::fromTokens(new self(root: $root), $tokens);
-                }
                 break;
         }
 
@@ -122,15 +119,8 @@ final class ExpressionNode implements \JsonSerializable
         }
 
         Scanner::skipSpaceAndComments($tokens);
-        if (Scanner::isEnd($tokens) || $precedence->mustStopAt(Scanner::type($tokens))) {
-            return new self(
-                root: $root
-            );
-        }
 
-        while ($tokens->valid()) {
-            Scanner::skipSpaceAndComments($tokens);
-
+        while (!Scanner::isEnd($tokens) && !$precedence->mustStopAt(Scanner::type($tokens))) {
             switch (Scanner::type($tokens)) {
                 case TokenType::OPERATOR_BOOLEAN_AND:
                 case TokenType::OPERATOR_BOOLEAN_OR:
@@ -157,6 +147,8 @@ final class ExpressionNode implements \JsonSerializable
                 default:
                     break 2;
             }
+
+            Scanner::skipSpaceAndComments($tokens);
         }
 
         return new self(

--- a/test/Unit/Target/Php/Transpiler/TernaryOperation/TernaryOperationTranspilerTest.php
+++ b/test/Unit/Target/Php/Transpiler/TernaryOperation/TernaryOperationTranspilerTest.php
@@ -59,9 +59,11 @@ final class TernaryOperationTranspilerTest extends TestCase
             'true === someStruct.foo ? "a" : "foo"' => ['true === someStruct.foo ? "a" : "foo"', '((true === $this->someStruct->foo) ? \'a\' : \'foo\')'],
             'true === someStruct.deep.foo ? "a" : "foo"' => ['true === someStruct.deep.foo ? "a" : "foo"', '((true === $this->someStruct->deep->foo) ? \'a\' : \'foo\')'],
             'someStruct.foo === true ? "a" : "foo"' => ['someStruct.foo === true ? "a" : "foo"', '(($this->someStruct->foo === true) ? \'a\' : \'foo\')'],
+            'someStruct.foo === true || false ? "a" : "foo"' => ['someStruct.foo === true || false ? "a" : "foo"', '(($this->someStruct->foo === true || false) ? \'a\' : \'foo\')'],
+            '1 + 2 + 3 === a || 5 * b || c === true && false ? "a" : "foo"' => ['1 + 2 + 3 === a || 5 * b || c === true && false ? "a" : "foo"', '((1 + 2 + 3 === $this->a || 5 * $this->b || $this->c === true && false) ? \'a\' : \'foo\')'],
         ];
     }
-    
+
     /**
      * @dataProvider ternaryOperationExamples
      * @dataProvider ternaryOperationWithVariablesInConditionExamples
@@ -74,7 +76,7 @@ final class TernaryOperationTranspilerTest extends TestCase
     {
         $ternaryOperationTranspiler = new TernaryOperationTranspiler(
             scope: new DummyScope([
-                "someString" => StringType::get(), 
+                "someString" => StringType::get(),
                 "someStruct" => StructType::fromStructDeclarationNode(
                     StructDeclarationNode::fromString(<<<'AFX'
                     struct SomeStruct {

--- a/test/Unit/Target/Php/Transpiler/TernaryOperation/TernaryOperationTranspilerTest.php
+++ b/test/Unit/Target/Php/Transpiler/TernaryOperation/TernaryOperationTranspilerTest.php
@@ -49,7 +49,10 @@ final class TernaryOperationTranspilerTest extends TestCase
         ];
     }
 
-    public function ternaryOperationWithVariablesInConditionExamples()
+    /**
+     * @return array<string,mixed>
+     */
+    public function ternaryOperationWithVariablesInConditionExamples(): array
     {
         return [
             'true === someString ? "a" : "foo"' => ['true === someString ? "a" : "foo"', '((true === $this->someString) ? \'a\' : \'foo\')'],


### PR DESCRIPTION
previously:

`true === someStruct.foo ? "a" : "foo"` is not correctly transpiled. (Its valid ecmascript see the ast that should be build: https://astexplorer.net)

```
Failed asserting that two strings are equal.
    Expected :'((true === $this->someStruct->foo) ? 'a' : 'foo')'
    Actual   :'(true === ($this->someStruct->foo ? 'a' : 'foo'))'
```

~i looked now a long time at this code, and still dont know if this is the right solution or if we need to fix the precedence of something ...~
