### PR TITLE
DISCUSSION: WIP: Transpile `||` and `&&` correctly to php (with ecmascript behaviour)

### DIFF
--- a/test/Unit/Target/Php/Transpiler/BinaryOperation/BinaryOperationTranspilerTest.php
+++ b/test/Unit/Target/Php/Transpiler/BinaryOperation/BinaryOperationTranspilerTest.php
@@ -36,6 +36,11 @@ final class BinaryOperationTranspilerTest extends TestCase
     public function binaryOperationExamples(): array
     {
         return [
+            // in php the or operator is not 100% equivalent to ecmascript
+            // `null || "fallback"` will be `true` in php but we want "fallback" like in js
+            'null || "fallback"' => '($temp_123 = null) ? $temp_123 : "fallback"',
+            'null && "fallback"' => '($temp_123 = null) ? "fallback" : $temp_123',
+
             'true && false' => ['true && false', '(true && false)'],
             'a && false' => ['a && false', '($this->a && false)'],
             'true && b' => ['true && b', '(true && $this->b)'],


### PR DESCRIPTION
The proposed expected php transpilation is inspired how EEL archieves it:
https://github.com/neos/flow-development-collection/blob/70bc49cc946c443dadfe26c49a19d710ece4ad48/Neos.Eel/Classes/CompilingEelParser.php#L163-L180
the simplified eel transpilation of "||" would look like: `($leftExpressionResult = $leftExpression) ? $leftExpressionResult : $rightExpression`

Todo:
- [ ] We need to have a concept for generating temporal variable ids without nameclash


While thinking of other differences in php and javascript, the truthyness came to my mind.
If we are not carefull a string `"0"` will be considered by the transpiled php falsy instead of truthy (by es standard)

The biggest problem is see, is that our testcases will be obscurified. Currently its super easy to read them as they nearly transpile 1 to 1 to php. But when we want ecmascript behaviour we need to use our own truthy helpers and transpile "and" and "or" correctly. This will lead to more bloat in the transpilation everywhere. We currently mostly test the AST and parsing by asserting the transpilation worked correctly, and if we want to write less transpilation tests we dont test the parsing that extensively anymore. Maybe we can build an easy back to AFX transpiler so we know that parsing worked without asserting the AST structure?
